### PR TITLE
Infallibility update

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -61,12 +61,50 @@ public final class Constants {
 
         public static final double kTurningScale = 0.5;
 
-        public static final double beamBalancedDriveKP = 0.018; // P (Proportional) constant of PID loop
+        /**
+         * The P value used in the {@link frc.robot.commands.BalanceCommand BalanceCommand} when balancing.
+         * <p>
+         *     This value is multiplied by the difference between the intended pitch (0°) and the current pitch,
+         *     and then fed to the motors to climb the charging station properly.
+         * </p>
+         * <br>
+         * <p>
+         *     If the robot is climbing too quickly and overshooting, consider lowering this value.
+         *     If it is not making it up, a higher P value may be necessary.
+         *     0.017 was used in competition to consistent (-1 instance) success.
+         * </p>
+         * <p>
+         *     Depending on where this is being used, consider changing other variables,
+         *     such as how long the robot drives for before switching to balancing.
+         *     This value is not merely a speed multiplier, but rather a determiner of how well the robot achieves balancing.
+         * </p>
+         */
+        public static final double beamBalancedDriveKP = 0.018;
+        /**
+         * The goal for the {@link frc.robot.commands.BalanceCommand BalanceCommand} to reach
+         */
         public static final double beamBalancedGoalDegrees = 0;
+        /**
+         * The angle threshold below which the {@link frc.robot.commands.BalanceCommand BalanceCommand} will <strong>end</strong>
+         * <p>
+         *     A higher value is used to stop the robot driving as the station tips to level,
+         *     instead of requiring back-and-forth balancing that can lead to failure to balance in time
+         * </p>
+         */
         public static final double beamBalancedAngleThresholdDegrees = 10;
+        /**
+         * A multiplier for speed when running the robot backwards when balancing.
+         * <p>This may not be necessary, but is available in case strange weight characteristics crop up in the robot
+         */
         public static final double backwardBalancingExtraPowerMultiplier = 1;
 
+        /**
+         * The angle above which the {@link frc.robot.commands.DriveOverTiltCommand DriveOverTiltCommand} considers itself not level
+         */
         public static final double minOffLevelAngleDegrees = 10;
+        /**
+         * The threshold within which the {@link frc.robot.commands.DriveOverTiltCommand DriveOverTiltCommand} considers itself level
+         */
         public static final double levelAngleThresholdDegrees = 1;
     }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -64,7 +64,10 @@ public final class Constants {
         public static final double beamBalancedDriveKP = 0.017; // P (Proportional) constant of PID loop
         public static final double beamBalancedGoalDegrees = 0;
         public static final double beamBalancedAngleThresholdDegrees = 10;
-        public static final double backwardBalancingExtraPowerMultiplier = 1.35;
+        public static final double backwardBalancingExtraPowerMultiplier = 1;
+
+        public static final double minOffLevelAngleDegrees = 10;
+        public static final double levelAngleThresholdDegrees = 1;
     }
 
     public static final class Arm {
@@ -101,10 +104,5 @@ public final class Constants {
         public static final double kSafePosition = -29.0;
         public static final int kCurrentLimit = 10;
         public static final PIDGains kPositionPIDGains = new PIDGains(0.2, 0.0, 0.0);
-    }
-    public static final class BalanceCommand {
-        // The time in (roughly) seconds that the robot has to be level
-        //  before stopping the balance command
-        public static final double levelTime = 1.0;
     }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -61,9 +61,9 @@ public final class Constants {
 
         public static final double kTurningScale = 0.5;
 
-        public static final double beamBalancedDriveKP = 0.019; // P (Proportional) constant of PID loop
+        public static final double beamBalancedDriveKP = 0.017; // P (Proportional) constant of PID loop
         public static final double beamBalancedGoalDegrees = 0;
-        public static final double beamBalancedAngleThresholdDegrees = 2;
+        public static final double beamBalancedAngleThresholdDegrees = 10;
         public static final double backwardBalancingExtraPowerMultiplier = 1.35;
     }
 
@@ -101,5 +101,10 @@ public final class Constants {
         public static final double kSafePosition = -29.0;
         public static final int kCurrentLimit = 10;
         public static final PIDGains kPositionPIDGains = new PIDGains(0.2, 0.0, 0.0);
+    }
+    public static final class BalanceCommand {
+        // The time in (roughly) seconds that the robot has to be level
+        //  before stopping the balance command
+        public static final double levelTime = 1.0;
     }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -79,7 +79,7 @@ public final class Constants {
          *     This value is not merely a speed multiplier, but rather a determiner of how well the robot achieves balancing.
          * </p>
          */
-        public static final double beamBalancedDriveKP = 0.018;
+        public static final double beamBalancedDriveKP = 0.017;
         /**
          * The goal for the {@link frc.robot.commands.BalanceCommand BalanceCommand} to reach
          */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -61,7 +61,7 @@ public final class Constants {
 
         public static final double kTurningScale = 0.5;
 
-        public static final double beamBalancedDriveKP = 0.017; // P (Proportional) constant of PID loop
+        public static final double beamBalancedDriveKP = 0.018; // P (Proportional) constant of PID loop
         public static final double beamBalancedGoalDegrees = 0;
         public static final double beamBalancedAngleThresholdDegrees = 10;
         public static final double backwardBalancingExtraPowerMultiplier = 1;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -68,14 +68,21 @@ public class RobotContainer {
                 "Short Side Auto",
                 new ScoreCommand(m_arm, m_gripper)
                         .andThen(new WaitCommand(0))
-                        .andThen(new DriveDistanceCommand(7.5, 0.3, true, m_drivetrain))
+                        .andThen(
+                                new RunCommand(() -> m_drivetrain.driveArcade(-0.6, 0), m_drivetrain)
+                                        .withTimeout(1.0)
+                        )
+
         );
         autonomousChooser.addOption(
                 "Long Side Auto",
                 new ScoreCommand(m_arm, m_gripper)
                         .andThen(new WaitCommand(0))
-                        .andThen(new RunCommand(() -> m_drivetrain.driveArcade(-0.6, 0)))
-                        .withTimeout(1.5)
+                        .andThen(
+                                new RunCommand(() -> m_drivetrain.driveArcade(-0.6, 0), m_drivetrain)
+                                        .withTimeout(1.7)
+                        )
+
         );
         autonomousChooser.addOption(
                 "Over Charge and Dock",

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -76,7 +76,8 @@ public class RobotContainer {
                 "Long Side Auto",
                 new ScoreCommand(m_arm, m_gripper)
                         .andThen(new WaitCommand(0))
-                        .andThen(new DriveDistanceCommand(12, 0.6, true, m_drivetrain))
+                        .andThen(new RunCommand(() -> m_drivetrain.driveArcade(-0.6, 0)))
+                        .withTimeout(1.5)
         );
         autonomousChooser.addOption(
                 "Over Charge and Dock",

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -94,7 +94,7 @@ public class RobotContainer {
                                 .andThen(new DriveOverTiltCommand(m_drivetrain, -1, 1.5))
                         )
                         .andThen(new WaitCommand(1))
-                        .andThen(new DriveUntilTiltCommand(m_drivetrain, 1, 1.5))
+                        .andThen(new DriveUntilTiltCommand(m_drivetrain, 1, 1.3))
                         .andThen(new BalanceCommand(m_drivetrain))
         );
         autonomousChooser.addOption(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -10,10 +10,7 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.*;
-import frc.robot.commands.BalanceCommand;
-import frc.robot.commands.DriveDistanceCommand;
-import frc.robot.commands.DriveUntilTiltCommand;
-import frc.robot.commands.ScoreCommand;
+import frc.robot.commands.*;
 import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.DrivetrainSubsystem;
 import frc.robot.subsystems.GripperSubsystem;
@@ -84,24 +81,15 @@ public class RobotContainer {
                 "Over Charge and Dock",
                 new ScoreCommand(m_arm, m_gripper)
                         .andThen(new WaitCommand(0))
-                        .andThen(new DriveDistanceCommand(13.5, 0.4, true, m_drivetrain))
+                        .andThen(new DriveOverTiltCommand(m_drivetrain, -1, 1.5))
                         .andThen(new WaitCommand(1))
-                        .andThen(new DriveDistanceCommand(8.7, 0.4, false, m_drivetrain))
-        );
-        autonomousChooser.addOption(
-                "Over Charge and Dock With Balancer",
-                new ScoreCommand(m_arm, m_gripper)
-                        .andThen(new WaitCommand(0))
-                        .andThen(new DriveDistanceCommand(10, 0.4, true, m_drivetrain))
-                        .andThen(new InstantCommand(() -> m_drivetrain.driveArcade(0,0)))
-                        .andThen(new WaitCommand(1))
-                        .andThen(new DriveDistanceCommand(5.3, 0.4, false, m_drivetrain))
+                        .andThen(new DriveUntilTiltCommand(m_drivetrain, 1, 1))
                         .andThen(new BalanceCommand(m_drivetrain))
         );
         autonomousChooser.addOption(
                 "Dock",
                 new ScoreCommand(m_arm, m_gripper)
-                        .andThen(new DriveUntilTiltCommand(m_drivetrain, -1))
+                        .andThen(new DriveUntilTiltCommand(m_drivetrain, -1, 1))
                         .andThen(new BalanceCommand(m_drivetrain))
         );
         autonomousChooser.addOption(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -80,10 +80,12 @@ public class RobotContainer {
         autonomousChooser.addOption(
                 "Over Charge and Dock",
                 new ScoreCommand(m_arm, m_gripper)
-                        .andThen(new WaitCommand(0))
-                        .andThen(new DriveOverTiltCommand(m_drivetrain, -1, 1.5))
+                        .alongWith(
+                                new WaitCommand(4)
+                                .andThen(new DriveOverTiltCommand(m_drivetrain, -1, 1.5))
+                        )
                         .andThen(new WaitCommand(1))
-                        .andThen(new DriveUntilTiltCommand(m_drivetrain, 1, 1))
+                        .andThen(new DriveUntilTiltCommand(m_drivetrain, 1, 1.5))
                         .andThen(new BalanceCommand(m_drivetrain))
         );
         autonomousChooser.addOption(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.*;
 import frc.robot.commands.BalanceCommand;
 import frc.robot.commands.DriveDistanceCommand;
+import frc.robot.commands.DriveUntilTiltCommand;
 import frc.robot.commands.ScoreCommand;
 import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.DrivetrainSubsystem;
@@ -91,9 +92,16 @@ public class RobotContainer {
                 "Over Charge and Dock With Balancer",
                 new ScoreCommand(m_arm, m_gripper)
                         .andThen(new WaitCommand(0))
-                        .andThen(new DriveDistanceCommand(13.5, 0.4, true, m_drivetrain))
+                        .andThen(new DriveDistanceCommand(10, 0.4, true, m_drivetrain))
+                        .andThen(new InstantCommand(() -> m_drivetrain.driveArcade(0,0)))
                         .andThen(new WaitCommand(1))
-                        .andThen(new DriveDistanceCommand(5.15, 0.4, false, m_drivetrain))
+                        .andThen(new DriveDistanceCommand(5.3, 0.4, false, m_drivetrain))
+                        .andThen(new BalanceCommand(m_drivetrain))
+        );
+        autonomousChooser.addOption(
+                "Dock",
+                new ScoreCommand(m_arm, m_gripper)
+                        .andThen(new DriveUntilTiltCommand(m_drivetrain, -1))
                         .andThen(new BalanceCommand(m_drivetrain))
         );
         autonomousChooser.addOption(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -96,7 +96,7 @@ public class RobotContainer {
                         .andThen(new BalanceCommand(m_drivetrain))
         );
         autonomousChooser.addOption(
-                "Dock",
+                "Dock (without mobility)",
                 new ScoreCommand(m_arm, m_gripper)
                         .andThen(new DriveUntilTiltCommand(m_drivetrain, -1, 1))
                         .andThen(new BalanceCommand(m_drivetrain))

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -87,7 +87,9 @@ public class RobotContainer {
         autonomousChooser.addOption(
                 "Over Charge and Dock",
                 new ScoreCommand(m_arm, m_gripper)
-                        .alongWith(
+                        .alongWith( // Begins driving while the ScoreCommand is finishing up, shaving out about a second
+                                // The .andThen block could be moved out in case of concerns for the safety of the arm,
+                                // As it just makes it down before the robot reaches the charging station
                                 new WaitCommand(4)
                                 .andThen(new DriveOverTiltCommand(m_drivetrain, -1, 1.5))
                         )

--- a/src/main/java/frc/robot/commands/DriveOverTiltCommand.java
+++ b/src/main/java/frc/robot/commands/DriveOverTiltCommand.java
@@ -1,0 +1,57 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
+import frc.robot.subsystems.DrivetrainSubsystem;
+
+
+public class DriveOverTiltCommand extends CommandBase {
+    private final DrivetrainSubsystem drivetrainSubsystem;
+    private double speed = 0.4;
+    private double time = 0.0;
+    private final double maxFlatTime;
+    private boolean hasTilted = false;
+
+    public DriveOverTiltCommand(DrivetrainSubsystem drivetrainSubsystem, int direction, double flatTime) {
+
+        maxFlatTime = flatTime;
+        speed = Math.copySign(speed, direction);
+
+        this.drivetrainSubsystem = drivetrainSubsystem;
+        // each subsystem used by the command must be passed into the
+        // addRequirements() method (which takes a vararg of Subsystem)
+        addRequirements(this.drivetrainSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        drivetrainSubsystem.zeroGyro();
+    }
+
+    @Override
+    public void execute() {
+        drivetrainSubsystem.driveArcade(speed, 0);
+    }
+
+    @Override
+    public boolean isFinished() {
+
+        double pitch = drivetrainSubsystem.getPitch();
+
+        if (!hasTilted)
+            hasTilted = pitch > Constants.Drivetrain.minOffLevelAngleDegrees ||
+                    pitch < -Constants.Drivetrain.minOffLevelAngleDegrees;
+
+        else
+            time += (pitch < Constants.Drivetrain.levelAngleThresholdDegrees ||
+                    pitch > -Constants.Drivetrain.levelAngleThresholdDegrees) ?
+                    0.02 : 0; // Adds 0.02 seconds (loop time for functions) whenever the angle is outside the threshold
+
+        return (time >= maxFlatTime);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+
+    }
+}

--- a/src/main/java/frc/robot/commands/DriveOverTiltCommand.java
+++ b/src/main/java/frc/robot/commands/DriveOverTiltCommand.java
@@ -8,10 +8,22 @@ import frc.robot.subsystems.DrivetrainSubsystem;
 public class DriveOverTiltCommand extends CommandBase {
     private final DrivetrainSubsystem drivetrainSubsystem;
     private double speed = 0.4;
+    /**
+     * The time for which the robot has been at a non-zero pitch.
+     * <p>
+     * As with the {@link DriveUntilTiltCommand}, 0.02 is added to this on every iteration of the function, meaning it is not truly in seconds.
+     * Consider adding something using System.currentTimeMillis() or System.nanoTime() to calculate the number in actual seconds if the results are proving inconsistent
+     */
     private double time = 0.0;
     private final double maxFlatTime;
     private boolean hasTilted = false;
 
+    /**
+     * Constructs a command that will drive the robot over a tilted surface (the charging station)
+     * @param drivetrainSubsystem The drivetrain for the robot, for driving and gyro access
+     * @param direction The direction in which to drive. A negative number will drive backwards, a positive one forwards
+     * @param flatTime The time (based on loop iterations running at 0.02 seconds) that the robot needs to be flat before stopping
+     */
     public DriveOverTiltCommand(DrivetrainSubsystem drivetrainSubsystem, int direction, double flatTime) {
 
         maxFlatTime = flatTime;

--- a/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
+++ b/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
@@ -1,0 +1,47 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.DrivetrainSubsystem;
+
+
+public class DriveUntilTiltCommand extends CommandBase {
+    private final DrivetrainSubsystem drivetrainSubsystem;
+    private double speed = 0.4;
+
+    public DriveUntilTiltCommand(DrivetrainSubsystem drivetrainSubsystem, int direction) {
+        this.drivetrainSubsystem = drivetrainSubsystem;
+        // each subsystem used by the command must be passed into the
+        // addRequirements() method (which takes a vararg of Subsystem)
+        addRequirements(this.drivetrainSubsystem);
+        speed = Math.copySign(speed, direction);
+    }
+
+    @Override
+    public void initialize() {
+        drivetrainSubsystem.zeroGyro();
+    }
+
+    @Override
+    public void execute() {
+        drivetrainSubsystem.driveArcade(speed,0);
+    }
+
+    private double time = 0.0;
+
+    @Override
+    public boolean isFinished() {
+
+        if (drivetrainSubsystem.getPitch() > 3 || drivetrainSubsystem.getPitch() < -3) {
+            time += 0.02;
+            if (time > 1) {
+                return drivetrainSubsystem.getPitch() > 3 || drivetrainSubsystem.getPitch() < -3;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+
+    }
+}

--- a/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
+++ b/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
@@ -6,12 +6,26 @@ import frc.robot.subsystems.DrivetrainSubsystem;
 
 public class DriveUntilTiltCommand extends CommandBase {
     private final DrivetrainSubsystem drivetrainSubsystem;
+    /**
+     * The speed (direction is copied in the constructor) that the robot will drive at while executing the command
+     */
     private double speed = 0.4;
+    /**
+     * The time for which the robot has been at a non-zero pitch.
+     * <p>
+     * As with the {@link DriveOverTiltCommand}, 0.02 is added to this on every iteration of the function, meaning it is not truly in seconds.
+     * Consider adding something using System.currentTimeMillis() or System.nanoTime() to calculate the number in actual seconds if the results are proving inconsistent
+     */
     private double time = 0.0;
 
     private final double drivePastSeconds;
 
-
+    /**
+     * Drives the robot until it reaches an incline
+     * @param drivetrainSubsystem The drivetrain for the robot, for driving and gyro access
+     * @param direction The direction in which to drive. A negative number will drive backwards, a positive one forwards
+     * @param _drivePastSeconds How many seconds (calculated based on command scheduler loops of 0.02 seconds) past when an incline is detected that the robot should continue driving
+     */
     public DriveUntilTiltCommand(DrivetrainSubsystem drivetrainSubsystem, int direction, double _drivePastSeconds) {
         this.drivetrainSubsystem = drivetrainSubsystem;
         // each subsystem used by the command must be passed into the

--- a/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
+++ b/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
@@ -7,18 +7,23 @@ import frc.robot.subsystems.DrivetrainSubsystem;
 public class DriveUntilTiltCommand extends CommandBase {
     private final DrivetrainSubsystem drivetrainSubsystem;
     private double speed = 0.4;
+    private double time = 0.0;
 
-    public DriveUntilTiltCommand(DrivetrainSubsystem drivetrainSubsystem, int direction) {
+    private final double drivePastSeconds;
+
+
+    public DriveUntilTiltCommand(DrivetrainSubsystem drivetrainSubsystem, int direction, double _drivePastSeconds) {
         this.drivetrainSubsystem = drivetrainSubsystem;
         // each subsystem used by the command must be passed into the
         // addRequirements() method (which takes a vararg of Subsystem)
         addRequirements(this.drivetrainSubsystem);
         speed = Math.copySign(speed, direction);
+        drivePastSeconds = _drivePastSeconds;
     }
 
     @Override
     public void initialize() {
-        drivetrainSubsystem.zeroGyro();
+
     }
 
     @Override
@@ -26,14 +31,13 @@ public class DriveUntilTiltCommand extends CommandBase {
         drivetrainSubsystem.driveArcade(speed,0);
     }
 
-    private double time = 0.0;
 
     @Override
     public boolean isFinished() {
 
         if (drivetrainSubsystem.getPitch() > 3 || drivetrainSubsystem.getPitch() < -3) {
             time += 0.02;
-            if (time > 1) {
+            if (time > drivePastSeconds) {
                 return drivetrainSubsystem.getPitch() > 3 || drivetrainSubsystem.getPitch() < -3;
             }
         }

--- a/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
+++ b/src/main/java/frc/robot/commands/DriveUntilTiltCommand.java
@@ -13,12 +13,15 @@ public class DriveUntilTiltCommand extends CommandBase {
     /**
      * The time for which the robot has been at a non-zero pitch.
      * <p>
-     * As with the {@link DriveOverTiltCommand}, 0.02 is added to this on every iteration of the function, meaning it is not truly in seconds.
-     * Consider adding something using System.currentTimeMillis() or System.nanoTime() to calculate the number in actual seconds if the results are proving inconsistent
+     * As with the {@link DriveOverTiltCommand}, time elapsed (based on System.nanoTime()) is added to this on every iteration of the function
      */
-    private double time = 0.0;
+    private long time = 0;
+    /**
+     * A snapshot of the last System.nanoTime() when it was measured
+     */
+    private long deltaTime = 0;
 
-    private final double drivePastSeconds;
+    private final long drivePastNanoseconds;
 
     /**
      * Drives the robot until it reaches an incline
@@ -32,7 +35,7 @@ public class DriveUntilTiltCommand extends CommandBase {
         // addRequirements() method (which takes a vararg of Subsystem)
         addRequirements(this.drivetrainSubsystem);
         speed = Math.copySign(speed, direction);
-        drivePastSeconds = _drivePastSeconds;
+        drivePastNanoseconds = (long) (_drivePastSeconds * 1000000000);
     }
 
     @Override
@@ -50,8 +53,10 @@ public class DriveUntilTiltCommand extends CommandBase {
     public boolean isFinished() {
 
         if (drivetrainSubsystem.getPitch() > 3 || drivetrainSubsystem.getPitch() < -3) {
-            time += 0.02;
-            if (time > drivePastSeconds) {
+            if (deltaTime == 0) deltaTime = System.nanoTime();
+            time += System.nanoTime() - deltaTime;
+            deltaTime = System.nanoTime();
+            if (time > drivePastNanoseconds) {
                 return drivetrainSubsystem.getPitch() > 3 || drivetrainSubsystem.getPitch() < -3;
             }
         }


### PR DESCRIPTION
Gyro-based balancing that has proven to work in competition paired with time-based long- and short-side autos means that with this update, the robot is capable (with some at-competition tweaking) of performing just as well as last competition, if not better, without worrying about encoders breaking.
If any changes are made to autonomous, I would recommend that these stay around anyway, just in case something goes wrong with the improved version.